### PR TITLE
bugfix: Set CookieSpecs to standard instead of default cause the defa…

### DIFF
--- a/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/HttpClientItem.java
+++ b/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/HttpClientItem.java
@@ -29,6 +29,7 @@ import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
@@ -119,6 +120,7 @@ class HttpClientItem {
 
     // timeout settings
     httpClientBuilder.setDefaultRequestConfig(RequestConfig.custom()
+        .setCookieSpec(CookieSpecs.STANDARD)
         .setConnectTimeout(config.getConnectTimeout())
         .setSocketTimeout(config.getSocketTimeout()).build());
 


### PR DESCRIPTION
…ult Spec does not support all 'expires' date patterns. For more info see: https://issues.apache.org/jira/browse/HTTPCLIENT-1763