### PR TITLE
WCARAV-14: Updates HttpClientFactory to return CloseableHttpClient

### DIFF
--- a/httpclient/changes.xml
+++ b/httpclient/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
   
+    <release version="2.0.0" date="not released">
+      <action type="update" dev="cnagel" issue="WCARAV-14">
+        HttpClientFactory returns CloseableHttpClient
+      </action>
+    </release>
+
     <release version="1.2.2" date="2019-03-06">
       <action type="add" dev="skrieg">
         Apply standard cookie policy to support all expire headers (see https://issues.apache.org/jira/browse/HTTPCLIENT-1763).

--- a/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/HttpClientFactory.java
+++ b/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/HttpClientFactory.java
@@ -22,6 +22,7 @@ package io.wcm.caravan.commons.httpclient;
 import java.net.URI;
 
 import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -36,7 +37,7 @@ public interface HttpClientFactory {
    * @param targetUrl Target URL to call (this url is not called, but required to check for configuration)
    * @return Http Client
    */
-  HttpClient get(String targetUrl);
+  CloseableHttpClient get(String targetUrl);
 
   /**
    * Returns a configured synchronous Http Client for the given target URL. If a special configuration
@@ -44,7 +45,7 @@ public interface HttpClientFactory {
    * @param targetUrl Target URL to call (this url is not called, but required to check for configuration)
    * @return Http Client
    */
-  HttpClient get(URI targetUrl);
+  CloseableHttpClient get(URI targetUrl);
 
   /**
    * Returns a configured synchronous Http Client for the given target URL. The Http Client is dedicated
@@ -55,7 +56,7 @@ public interface HttpClientFactory {
    * @param wsAddressingToUri WS Addressing "To" header
    * @return Http Client
    */
-  HttpClient getWs(String targetUrl, String wsAddressingToUri);
+  CloseableHttpClient getWs(String targetUrl, String wsAddressingToUri);
 
   /**
    * Returns a configured synchronous Http Client for the given target URL. The Http Client is dedicated
@@ -66,6 +67,6 @@ public interface HttpClientFactory {
    * @param wsAddressingToUri WS Addressing "To" header
    * @return Http Client
    */
-  HttpClient getWs(URI targetUrl, URI wsAddressingToUri);
+  CloseableHttpClient getWs(URI targetUrl, URI wsAddressingToUri);
 
 }

--- a/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/HttpClientFactoryImpl.java
+++ b/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/HttpClientFactoryImpl.java
@@ -33,7 +33,7 @@ import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.ReferenceCardinality;
 import org.apache.felix.scr.annotations.ReferencePolicy;
 import org.apache.felix.scr.annotations.Service;
-import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.sling.commons.osgi.ServiceUtil;
 import org.osgi.framework.BundleContext;
 
@@ -81,26 +81,26 @@ public class HttpClientFactoryImpl implements HttpClientFactory {
   }
 
   @Override
-  public HttpClient get(String targetUrl) {
+  public CloseableHttpClient get(String targetUrl) {
     final URI uri = toUri(targetUrl);
     final String path = uri != null ? uri.getPath() : null;
     return getFactoryItem(uri, null, path, false).getHttpClient();
   }
 
   @Override
-  public HttpClient get(URI targetUrl) {
+  public CloseableHttpClient get(URI targetUrl) {
     return getFactoryItem(targetUrl, null, targetUrl.getPath(), false).getHttpClient();
   }
 
   @Override
-  public HttpClient getWs(String targetUrl, String wsAddressingToUri) {
+  public CloseableHttpClient getWs(String targetUrl, String wsAddressingToUri) {
     final URI uri = toUri(targetUrl);
     final String path = uri != null ? uri.getPath() : null;
     return getFactoryItem(uri, wsAddressingToUri, path, true).getHttpClient();
   }
 
   @Override
-  public HttpClient getWs(URI targetUrl, URI wsAddressingToUri) {
+  public CloseableHttpClient getWs(URI targetUrl, URI wsAddressingToUri) {
     return getFactoryItem(targetUrl, wsAddressingToUri.toString(), targetUrl.getPath(), true).getHttpClient();
   }
 

--- a/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/package-info.java
+++ b/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/package-info.java
@@ -20,5 +20,5 @@
 /**
  * HTTP Client Factory.
  */
-@org.osgi.annotation.versioning.Version("1.2.0")
+@org.osgi.annotation.versioning.Version("2.0.0")
 package io.wcm.caravan.commons.httpclient;


### PR DESCRIPTION
To work with CloseableHttpResponse the HttpClientFactory should return a CloseableHttpClient. It only needs to change the API - the implementation already returns this type.