### PR TITLE
WCARAV-21 Make CookieSpecs configurable

### DIFF
--- a/httpasyncclient/changes.xml
+++ b/httpasyncclient/changes.xml
@@ -24,6 +24,9 @@
   <body>
 
     <release version="1.4.0" date="not released">
+      <action type="add" dev="sseifert">
+        Make CookieSpecs configurable to be used for HttpAsyncClient. Defaults to STANDARD (RFC 2965 compliant policy).
+      </action>
       <action type="update" dev="sseifert">
         Switch to individual OSGI artifacts.
       </action>

--- a/httpasyncclient/src/main/java/io/wcm/caravan/commons/httpasyncclient/impl/HttpAsyncClientItem.java
+++ b/httpasyncclient/src/main/java/io/wcm/caravan/commons/httpasyncclient/impl/HttpAsyncClientItem.java
@@ -135,7 +135,9 @@ class HttpAsyncClientItem {
     httpClientAsyncBuilder.setDefaultRequestConfig(RequestConfig.custom()
         .setConnectionRequestTimeout(config.getConnectionRequestTimeout())
         .setConnectTimeout(config.getConnectTimeout())
-        .setSocketTimeout(config.getSocketTimeout()).build());
+        .setSocketTimeout(config.getSocketTimeout())
+        .setCookieSpec(config.getCookieSpec())
+        .build());
 
     httpClientAsyncBuilder.setDefaultCredentialsProvider(credentialsProvider);
 

--- a/httpasyncclient/src/test/java/io/wcm/caravan/commons/httpasyncclient/impl/HttpClientItemAsyncTest.java
+++ b/httpasyncclient/src/test/java/io/wcm/caravan/commons/httpasyncclient/impl/HttpClientItemAsyncTest.java
@@ -21,6 +21,7 @@ package io.wcm.caravan.commons.httpasyncclient.impl;
 
 import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.CONNECTION_REQUEST_TIMEOUT_PROPERTY;
 import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.CONNECT_TIMEOUT_PROPERTY;
+import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.COOKIE_SPEC_PROPERTY;
 import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.HTTP_PASSWORD_PROPERTY;
 import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.HTTP_USER_PROPERTY;
 import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.KEYSTORE_PASSWORD_PROPERTY;
@@ -38,11 +39,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl;
 
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.Registry;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
@@ -54,6 +55,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
+
+import io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl;
 
 public class HttpClientItemAsyncTest {
 
@@ -192,6 +195,19 @@ public class HttpClientItemAsyncTest {
 
     assertNotEquals(schemeSocketFactory, SSLConnectionSocketFactory.getSocketFactory());
     item.close();
+  }
+
+  @Test
+  public void testWithCookieSpec() {
+    HttpClientConfigImpl config = context.registerInjectActivateService(new HttpClientConfigImpl(),
+        ImmutableMap.<String, Object>builder()
+            .put(COOKIE_SPEC_PROPERTY, CookieSpecs.IGNORE_COOKIES)
+            .build());
+
+    HttpAsyncClientItem item = new HttpAsyncClientItem(config);
+    HttpAsyncClient client = item.getHttpAsyncClient();
+    RequestConfig requestConfig = HttpClientTestUtils.getDefaultRequestConfig(client);
+    assertEquals(CookieSpecs.IGNORE_COOKIES, requestConfig.getCookieSpec());
   }
 
 }

--- a/httpclient/changes.xml
+++ b/httpclient/changes.xml
@@ -24,6 +24,9 @@
   <body>
   
     <release version="1.4.0" date="not released">
+      <action type="add" dev="sseifert">
+        Make CookieSpecs configurable to be used for HttpClient. Defaults to STANDARD (RFC 2965 compliant policy).
+      </action>
       <action type="update" dev="sseifert">
         Switch to individual OSGI artifacts.
       </action>

--- a/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/HttpClientConfig.java
+++ b/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/HttpClientConfig.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.caravan.commons.httpclient;
 
+import org.apache.http.client.config.CookieSpecs;
 import org.osgi.annotation.versioning.ConsumerType;
 
 /**
@@ -51,6 +52,11 @@ public interface HttpClientConfig {
    * Default value for maximum total connections
    */
   int MAX_TOTAL_CONNECTIONS_DEFAULT = 50;
+
+  /**
+   * Default value for cookie specs.
+   */
+  String COOKIE_SPEC_DEFAULT = CookieSpecs.STANDARD;
 
   /**
    * Configuration enabled.
@@ -89,6 +95,12 @@ public interface HttpClientConfig {
    * @return Maximal total HTTP connections.
    */
   int getMaxTotalConnections();
+
+  /**
+   * Standard cookie specification for HttpClient.
+   * @return Cookie spec
+   */
+  String getCookieSpec();
 
   /**
    * Http basic authentication user (optional).

--- a/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/HttpClientConfigImpl.java
+++ b/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/HttpClientConfigImpl.java
@@ -106,11 +106,11 @@ public class HttpClientConfigImpl extends AbstractHttpClientConfig {
     @AttributeDefinition(name = "Cookie Spec", description = "Standard cookie specification for HttpClient. "
         + "See https://www.javadoc.io/static/org.apache.httpcomponents/httpclient/4.3.4/org/apache/http/client/config/CookieSpecs.html",
         options = {
-            @Option(label = CookieSpecs.BROWSER_COMPATIBILITY, value = "BROWSER_COMPATIBILITY"),
-            @Option(label = CookieSpecs.NETSCAPE, value = "NETSCAPE"),
-            @Option(label = CookieSpecs.STANDARD, value = "STANDARD"),
-            @Option(label = CookieSpecs.BEST_MATCH, value = "BEST_MATCH"),
-            @Option(label = CookieSpecs.IGNORE_COOKIES, value = "IGNORE_COOKIES")
+            @Option(value = CookieSpecs.BROWSER_COMPATIBILITY, label = "BROWSER_COMPATIBILITY"),
+            @Option(value = CookieSpecs.NETSCAPE, label = "NETSCAPE"),
+            @Option(value = CookieSpecs.STANDARD, label = "STANDARD"),
+            @Option(value = CookieSpecs.BEST_MATCH, label = "BEST_MATCH"),
+            @Option(value = CookieSpecs.IGNORE_COOKIES, label = "IGNORE_COOKIES")
         })
     String cookieSpec() default HttpClientConfig.COOKIE_SPEC_DEFAULT;
 

--- a/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/HttpClientConfigImpl.java
+++ b/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/HttpClientConfigImpl.java
@@ -30,7 +30,9 @@ import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.ConfigurationPolicy;
 import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.PropertyOption;
 import org.apache.felix.scr.annotations.Service;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.sling.commons.osgi.PropertiesUtil;
 import org.osgi.framework.Constants;
 import org.slf4j.Logger;
@@ -106,6 +108,21 @@ public class HttpClientConfigImpl extends AbstractHttpClientConfig {
   @Property(label = "Max total", description = "Max total connections",
       intValue = HttpClientConfig.MAX_TOTAL_CONNECTIONS_DEFAULT)
   public static final String MAX_TOTAL_CONNECTIONS_PROPERTY = "maxTotalConnections";
+
+  /**
+   * Cookie Specs
+   */
+  @Property(label = "Cookie Spec", description = "Standard cookie specification for HttpClient. "
+      + "See https://www.javadoc.io/static/org.apache.httpcomponents/httpclient/4.3.4/org/apache/http/client/config/CookieSpecs.html",
+      value = HttpClientConfig.COOKIE_SPEC_DEFAULT,
+      options = {
+          @PropertyOption(name = CookieSpecs.BROWSER_COMPATIBILITY, value = "BROWSER_COMPATIBILITY"),
+          @PropertyOption(name = CookieSpecs.NETSCAPE, value = "NETSCAPE"),
+          @PropertyOption(name = CookieSpecs.STANDARD, value = "STANDARD"),
+          @PropertyOption(name = CookieSpecs.BEST_MATCH, value = "BEST_MATCH"),
+          @PropertyOption(name = CookieSpecs.IGNORE_COOKIES, value = "IGNORE_COOKIES")
+      })
+  public static final String COOKIE_SPEC_PROPERTY = "cookieSpec";
 
   /**
    * Http user
@@ -232,6 +249,7 @@ public class HttpClientConfigImpl extends AbstractHttpClientConfig {
   private int socketTimeout;
   private int maxConnectionsPerHost;
   private int maxTotalConnections;
+  private String cookieSpec;
   private String httpUser;
   private String httpPassword;
   private String proxyHost;
@@ -265,6 +283,7 @@ public class HttpClientConfigImpl extends AbstractHttpClientConfig {
     socketTimeout = PropertiesUtil.toInteger(config.get(SOCKET_TIMEOUT_PROPERTY), HttpClientConfig.SOCKET_TIMEOUT_DEFAULT);
     maxConnectionsPerHost = PropertiesUtil.toInteger(config.get(MAX_CONNECTIONS_PER_HOST_PROPERTY), HttpClientConfig.MAX_CONNECTIONS_PER_HOST_DEFAULT);
     maxTotalConnections = PropertiesUtil.toInteger(config.get(MAX_TOTAL_CONNECTIONS_PROPERTY), HttpClientConfig.MAX_TOTAL_CONNECTIONS_DEFAULT);
+    cookieSpec = PropertiesUtil.toString(config.get(COOKIE_SPEC_PROPERTY), HttpClientConfig.COOKIE_SPEC_DEFAULT);
     httpUser = PropertiesUtil.toString(config.get(HTTP_USER_PROPERTY), null);
     httpPassword = PropertiesUtil.toString(config.get(HTTP_PASSWORD_PROPERTY), null);
     proxyHost = PropertiesUtil.toString(config.get(PROXY_HOST_PROPERTY), null);
@@ -349,6 +368,11 @@ public class HttpClientConfigImpl extends AbstractHttpClientConfig {
   @Override
   public int getMaxTotalConnections() {
     return maxTotalConnections;
+  }
+
+  @Override
+  public String getCookieSpec() {
+    return cookieSpec;
   }
 
   @Override

--- a/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/HttpClientItem.java
+++ b/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/HttpClientItem.java
@@ -29,7 +29,6 @@ import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
@@ -123,8 +122,7 @@ class HttpClientItem {
         .setConnectionRequestTimeout(config.getConnectionRequestTimeout())
         .setConnectTimeout(config.getConnectTimeout())
         .setSocketTimeout(config.getSocketTimeout())
-        // apply standard cookie policy to support all expire headers (see https://issues.apache.org/jira/browse/HTTPCLIENT-1763)
-        .setCookieSpec(CookieSpecs.STANDARD)
+        .setCookieSpec(config.getCookieSpec())
         .build());
 
     httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);

--- a/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/helpers/DefaultHttpClientConfig.java
+++ b/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/helpers/DefaultHttpClientConfig.java
@@ -66,6 +66,11 @@ public final class DefaultHttpClientConfig extends AbstractHttpClientConfig {
   }
 
   @Override
+  public String getCookieSpec() {
+    return HttpClientConfig.COOKIE_SPEC_DEFAULT;
+  }
+
+  @Override
   public String getHttpUser() {
     return null;
   }

--- a/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/package-info.java
+++ b/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/package-info.java
@@ -20,5 +20,5 @@
 /**
  * HTTP Client Factory.
  */
-@org.osgi.annotation.versioning.Version("1.3.0")
+@org.osgi.annotation.versioning.Version("1.4.0")
 package io.wcm.caravan.commons.httpclient;

--- a/httpclient/src/test/java/io/wcm/caravan/commons/httpclient/impl/HttpClientConfigImplTest.java
+++ b/httpclient/src/test/java/io/wcm/caravan/commons/httpclient/impl/HttpClientConfigImplTest.java
@@ -99,27 +99,27 @@ public class HttpClientConfigImplTest {
   public void testReadFromConfig() {
     HttpClientConfigImpl config = context.registerInjectActivateService(new HttpClientConfigImpl(),
         ImmutableMap.<String, Object>builder()
-        .put(CONNECTION_REQUEST_TIMEOUT_PROPERTY, 5)
-        .put(CONNECT_TIMEOUT_PROPERTY, 1)
-        .put(SOCKET_TIMEOUT_PROPERTY, 2)
-        .put(MAX_CONNECTIONS_PER_HOST_PROPERTY, 3)
-        .put(MAX_TOTAL_CONNECTIONS_PROPERTY, 4)
+            .put(CONNECTION_REQUEST_TIMEOUT_PROPERTY, 5)
+            .put(CONNECT_TIMEOUT_PROPERTY, 1)
+            .put(SOCKET_TIMEOUT_PROPERTY, 2)
+            .put(MAX_CONNECTIONS_PER_HOST_PROPERTY, 3)
+            .put(MAX_TOTAL_CONNECTIONS_PROPERTY, 4)
             .put(COOKIE_SPEC_PROPERTY, CookieSpecs.IGNORE_COOKIES)
-        .put(HTTP_USER_PROPERTY, "httpUsr")
-        .put(HTTP_PASSWORD_PROPERTY, "httpPwd")
-        .put(PROXY_HOST_PROPERTY, "abc")
-        .put(PROXY_PORT_PROPERTY, 5)
-        .put(PROXY_USER_PROPERTY, "def")
-        .put(PROXY_PASSWORD_PROPERTY, "ghi")
-        .put(HOST_PATTERNS_PROPERTY, new String[] {
-            "h1",
-            "h2",
-            "h3"
-        })
-        .put(WS_ADDRESSINGTO_URIS_PROPERTY, new String[] {
-            "http://uri1",
-            "http://uri2"
-        })
+            .put(HTTP_USER_PROPERTY, "httpUsr")
+            .put(HTTP_PASSWORD_PROPERTY, "httpPwd")
+            .put(PROXY_HOST_PROPERTY, "abc")
+            .put(PROXY_PORT_PROPERTY, 5)
+            .put(PROXY_USER_PROPERTY, "def")
+            .put(PROXY_PASSWORD_PROPERTY, "ghi")
+            .put(HOST_PATTERNS_PROPERTY, new String[] {
+                "h1",
+                "h2",
+                "h3"
+            })
+            .put(WS_ADDRESSINGTO_URIS_PROPERTY, new String[] {
+                "http://uri1",
+                "http://uri2"
+            })
             .put(SSL_CONTEXT_TYPE_PROPERTY, "ssltype")
             .put(KEYMANAGER_TYPE_PROPERTY, "keymantype")
             .put(KEYSTORE_TYPE_PROPERTY, "keystoretype")
@@ -129,7 +129,7 @@ public class HttpClientConfigImplTest {
             .put(TRUSTSTORE_TYPE_PROPERTY, "truststoretype")
             .put(TRUSTSTORE_PATH_PROPERTY, "trustpath")
             .put(TRUSTSTORE_PASSWORD_PROPERTY, "trustpasswd")
-        .build());
+            .build());
 
     assertEquals(CONNECTION_REQUEST_TIMEOUT_PROPERTY, 5, config.getConnectionRequestTimeout());
     assertEquals(CONNECT_TIMEOUT_PROPERTY, 1, config.getConnectTimeout());

--- a/httpclient/src/test/java/io/wcm/caravan/commons/httpclient/impl/HttpClientConfigImplTest.java
+++ b/httpclient/src/test/java/io/wcm/caravan/commons/httpclient/impl/HttpClientConfigImplTest.java
@@ -21,6 +21,7 @@ package io.wcm.caravan.commons.httpclient.impl;
 
 import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.CONNECTION_REQUEST_TIMEOUT_PROPERTY;
 import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.CONNECT_TIMEOUT_PROPERTY;
+import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.COOKIE_SPEC_PROPERTY;
 import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.HOST_PATTERNS_PROPERTY;
 import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.HTTP_PASSWORD_PROPERTY;
 import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.HTTP_USER_PROPERTY;
@@ -41,10 +42,16 @@ import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.TRUSTS
 import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.TRUSTSTORE_PATH_PROPERTY;
 import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.TRUSTSTORE_TYPE_PROPERTY;
 import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.WS_ADDRESSINGTO_URIS_PROPERTY;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
-import org.junit.*;
+import org.junit.Rule;
+import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -65,6 +72,7 @@ public class HttpClientConfigImplTest {
     assertEquals(SOCKET_TIMEOUT_PROPERTY, HttpClientConfig.SOCKET_TIMEOUT_DEFAULT, config.getSocketTimeout());
     assertEquals(MAX_CONNECTIONS_PER_HOST_PROPERTY, HttpClientConfig.MAX_CONNECTIONS_PER_HOST_DEFAULT, config.getMaxConnectionsPerHost());
     assertEquals(MAX_TOTAL_CONNECTIONS_PROPERTY, HttpClientConfig.MAX_TOTAL_CONNECTIONS_DEFAULT, config.getMaxTotalConnections());
+    assertEquals(COOKIE_SPEC_PROPERTY, HttpClientConfig.COOKIE_SPEC_DEFAULT, config.getCookieSpec());
     assertNull(HTTP_USER_PROPERTY, config.getHttpUser());
     assertNull(HTTP_PASSWORD_PROPERTY, config.getHttpPassword());
     assertNull(PROXY_HOST_PROPERTY, config.getProxyHost());
@@ -96,6 +104,7 @@ public class HttpClientConfigImplTest {
         .put(SOCKET_TIMEOUT_PROPERTY, 2)
         .put(MAX_CONNECTIONS_PER_HOST_PROPERTY, 3)
         .put(MAX_TOTAL_CONNECTIONS_PROPERTY, 4)
+            .put(COOKIE_SPEC_PROPERTY, CookieSpecs.IGNORE_COOKIES)
         .put(HTTP_USER_PROPERTY, "httpUsr")
         .put(HTTP_PASSWORD_PROPERTY, "httpPwd")
         .put(PROXY_HOST_PROPERTY, "abc")
@@ -127,6 +136,7 @@ public class HttpClientConfigImplTest {
     assertEquals(SOCKET_TIMEOUT_PROPERTY, 2, config.getSocketTimeout());
     assertEquals(MAX_CONNECTIONS_PER_HOST_PROPERTY, 3, config.getMaxConnectionsPerHost());
     assertEquals(MAX_TOTAL_CONNECTIONS_PROPERTY, 4, config.getMaxTotalConnections());
+    assertEquals(COOKIE_SPEC_PROPERTY, CookieSpecs.IGNORE_COOKIES, config.getCookieSpec());
     assertEquals(HTTP_USER_PROPERTY, "httpUsr", config.getHttpUser());
     assertEquals(HTTP_PASSWORD_PROPERTY, "httpPwd", config.getHttpPassword());
     assertEquals(PROXY_HOST_PROPERTY, "abc", config.getProxyHost());

--- a/httpclient/src/test/java/io/wcm/caravan/commons/httpclient/impl/HttpClientItemTest.java
+++ b/httpclient/src/test/java/io/wcm/caravan/commons/httpclient/impl/HttpClientItemTest.java
@@ -21,6 +21,7 @@ package io.wcm.caravan.commons.httpclient.impl;
 
 import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.CONNECTION_REQUEST_TIMEOUT_PROPERTY;
 import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.CONNECT_TIMEOUT_PROPERTY;
+import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.COOKIE_SPEC_PROPERTY;
 import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.HOST_PATTERNS_PROPERTY;
 import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.HTTP_PASSWORD_PROPERTY;
 import static io.wcm.caravan.commons.httpclient.impl.HttpClientConfigImpl.HTTP_USER_PROPERTY;
@@ -48,6 +49,7 @@ import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.Registry;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
@@ -378,6 +380,19 @@ public class HttpClientItemTest {
 
     assertNotEquals(schemeSocketFactory, SSLConnectionSocketFactory.getSocketFactory());
     item.close();
+  }
+
+  @Test
+  public void testWithCookieSpec() {
+    HttpClientConfigImpl config = context.registerInjectActivateService(new HttpClientConfigImpl(),
+        ImmutableMap.<String, Object>builder()
+            .put(COOKIE_SPEC_PROPERTY, CookieSpecs.IGNORE_COOKIES)
+            .build());
+
+    HttpClientItem item = new HttpClientItem(config);
+    HttpClient client = item.getHttpClient();
+    RequestConfig requestConfig = HttpClientTestUtils.getDefaultRequestConfig(client);
+    assertEquals(CookieSpecs.IGNORE_COOKIES, requestConfig.getCookieSpec());
   }
 
 }


### PR DESCRIPTION
Make CookieSpecs configurable to be used for HttpClient/HttpAsyncClient.
Defaults to STANDARD (RFC 2965 compliant policy).