### PR TITLE
Apply null-annotations to all interfaces

### DIFF
--- a/httpasyncclient/src/main/java/io/wcm/caravan/commons/httpasyncclient/HttpAsyncClientFactory.java
+++ b/httpasyncclient/src/main/java/io/wcm/caravan/commons/httpasyncclient/HttpAsyncClientFactory.java
@@ -24,6 +24,8 @@ import java.net.URI;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.nio.client.HttpAsyncClient;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -38,7 +40,8 @@ public interface HttpAsyncClientFactory {
    * @param targetUrl Target URL to call (this url is not called, but required to check for configuration)
    * @return Http Client
    */
-  HttpAsyncClient get(String targetUrl);
+  @NotNull
+  HttpAsyncClient get(@Nullable String targetUrl);
 
   /**
    * Returns a configured asynchronous Http Client for the given target URL. If a special configuration
@@ -46,7 +49,8 @@ public interface HttpAsyncClientFactory {
    * @param targetUrl Target URL to call (this url is not called, but required to check for configuration)
    * @return Http Client
    */
-  CloseableHttpAsyncClient getCloseable(String targetUrl);
+  @NotNull
+  CloseableHttpAsyncClient getCloseable(@Nullable String targetUrl);
 
   /**
    * Returns a configured asynchronous Http Client for the given target URL. If a special configuration
@@ -54,7 +58,8 @@ public interface HttpAsyncClientFactory {
    * @param targetUrl Target URL to call (this url is not called, but required to check for configuration)
    * @return Http Client
    */
-  HttpAsyncClient get(URI targetUrl);
+  @NotNull
+  HttpAsyncClient get(@Nullable URI targetUrl);
 
   /**
    * Returns a configured asynchronous Http Client for the given target URL. If a special configuration
@@ -62,7 +67,8 @@ public interface HttpAsyncClientFactory {
    * @param targetUrl Target URL to call (this url is not called, but required to check for configuration)
    * @return Http Client
    */
-  CloseableHttpAsyncClient getCloseable(URI targetUrl);
+  @NotNull
+  CloseableHttpAsyncClient getCloseable(@Nullable URI targetUrl);
 
   /**
    * Returns a configured asynchronous Http Client for the given target URL. The Http Client is dedicated
@@ -73,7 +79,8 @@ public interface HttpAsyncClientFactory {
    * @param wsAddressingToUri WS Addressing "To" header
    * @return Http Client
    */
-  HttpAsyncClient getWs(String targetUrl, String wsAddressingToUri);
+  @NotNull
+  HttpAsyncClient getWs(@Nullable String targetUrl, @Nullable String wsAddressingToUri);
 
   /**
    * Returns a configured asynchronous Http Client for the given target URL. The Http Client is dedicated
@@ -84,7 +91,8 @@ public interface HttpAsyncClientFactory {
    * @param wsAddressingToUri WS Addressing "To" header
    * @return Http Client
    */
-  CloseableHttpAsyncClient getCloseableWs(String targetUrl, String wsAddressingToUri);
+  @NotNull
+  CloseableHttpAsyncClient getCloseableWs(@Nullable String targetUrl, @Nullable String wsAddressingToUri);
 
   /**
    * Returns a configured asynchronous Http Client for the given target URL. The Http Client is dedicated
@@ -95,7 +103,8 @@ public interface HttpAsyncClientFactory {
    * @param wsAddressingToUri WS Addressing "To" header
    * @return Http Client
    */
-  HttpAsyncClient getWs(URI targetUrl, URI wsAddressingToUri);
+  @NotNull
+  HttpAsyncClient getWs(@Nullable URI targetUrl, @Nullable URI wsAddressingToUri);
 
   /**
    * Returns a configured asynchronous Http Client for the given target URL. The Http Client is dedicated
@@ -106,7 +115,8 @@ public interface HttpAsyncClientFactory {
    * @param wsAddressingToUri WS Addressing "To" header
    * @return Http Client
    */
-  CloseableHttpAsyncClient getCloseableWs(URI targetUrl, URI wsAddressingToUri);
+  @NotNull
+  CloseableHttpAsyncClient getCloseableWs(@Nullable URI targetUrl, @Nullable URI wsAddressingToUri);
 
   /**
    * Returns the default Request Configuration for the given target URL. If a special configuration
@@ -114,7 +124,8 @@ public interface HttpAsyncClientFactory {
    * @param targetUrl Target URL to call (this url is not called, but required to check for configuration)
    * @return Default Request Config
    */
-  RequestConfig getDefaultRequestConfig(String targetUrl);
+  @NotNull
+  RequestConfig getDefaultRequestConfig(@Nullable String targetUrl);
 
   /**
    * Returns the default Request Configuration for the given target URL. If a special configuration
@@ -122,6 +133,7 @@ public interface HttpAsyncClientFactory {
    * @param targetUrl Target URL to call (this url is not called, but required to check for configuration)
    * @return Default Request Config
    */
-  RequestConfig getDefaultRequestConfig(URI targetUrl);
+  @NotNull
+  RequestConfig getDefaultRequestConfig(@Nullable URI targetUrl);
 
 }

--- a/httpasyncclient/src/main/java/io/wcm/caravan/commons/httpasyncclient/impl/HttpAsyncClientFactoryImpl.java
+++ b/httpasyncclient/src/main/java/io/wcm/caravan/commons/httpasyncclient/impl/HttpAsyncClientFactoryImpl.java
@@ -31,6 +31,8 @@ import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.nio.client.HttpAsyncClient;
 import org.apache.sling.commons.osgi.Order;
 import org.apache.sling.commons.osgi.ServiceUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -84,71 +86,75 @@ public class HttpAsyncClientFactoryImpl implements HttpAsyncClientFactory {
   }
 
   @Override
-  public HttpAsyncClient get(String targetUrl) {
+  public @NotNull HttpAsyncClient get(@Nullable String targetUrl) {
     return getCloseable(targetUrl);
   }
 
   @Override
-  public CloseableHttpAsyncClient getCloseable(String targetUrl) {
+  public @NotNull CloseableHttpAsyncClient getCloseable(@Nullable String targetUrl) {
     final URI uri = toUri(targetUrl);
     final String path = uri != null ? uri.getPath() : null;
     return getFactoryItem(uri, null, path, false).getHttpAsyncClient();
   }
 
   @Override
-  public HttpAsyncClient get(URI targetUrl) {
+  public @NotNull HttpAsyncClient get(@Nullable URI targetUrl) {
     return getCloseable(targetUrl);
   }
 
   @Override
-  public CloseableHttpAsyncClient getCloseable(URI targetUrl) {
-    return getFactoryItem(targetUrl, null, targetUrl.getPath(), false).getHttpAsyncClient();
+  public @NotNull CloseableHttpAsyncClient getCloseable(@Nullable URI targetUrl) {
+    final String path = targetUrl != null ? targetUrl.getPath() : null;
+    return getFactoryItem(targetUrl, null, path, false).getHttpAsyncClient();
   }
 
   @Override
-  public HttpAsyncClient getWs(String targetUrl, String wsAddressingToUri) {
+  public @NotNull HttpAsyncClient getWs(@Nullable String targetUrl, @Nullable String wsAddressingToUri) {
     return getCloseableWs(targetUrl, wsAddressingToUri);
   }
 
   @Override
-  public CloseableHttpAsyncClient getCloseableWs(String targetUrl, String wsAddressingToUri) {
+  public @NotNull CloseableHttpAsyncClient getCloseableWs(@Nullable String targetUrl, @Nullable String wsAddressingToUri) {
     final URI uri = toUri(targetUrl);
     final String path = uri != null ? uri.getPath() : null;
     return getFactoryItem(uri, wsAddressingToUri, path, true).getHttpAsyncClient();
   }
 
   @Override
-  public HttpAsyncClient getWs(URI targetUrl, URI wsAddressingToUri) {
+  public @NotNull HttpAsyncClient getWs(@Nullable URI targetUrl, @Nullable URI wsAddressingToUri) {
     return getCloseableWs(targetUrl, wsAddressingToUri);
   }
 
   @Override
-  public CloseableHttpAsyncClient getCloseableWs(URI targetUrl, URI wsAddressingToUri) {
-    return getFactoryItem(targetUrl, wsAddressingToUri.toString(), targetUrl.getPath(), true).getHttpAsyncClient();
+  public @NotNull CloseableHttpAsyncClient getCloseableWs(@Nullable URI targetUrl, @Nullable URI wsAddressingToUri) {
+    String wsAddressingToUriString = wsAddressingToUri != null ? wsAddressingToUri.toString() : null;
+    String path = targetUrl != null ? targetUrl.getPath() : null;
+    return getFactoryItem(targetUrl, wsAddressingToUriString, path, true).getHttpAsyncClient();
   }
 
   @Override
-  public RequestConfig getDefaultRequestConfig(String targetUrl) {
+  public @NotNull RequestConfig getDefaultRequestConfig(@Nullable String targetUrl) {
     final URI uri = toUri(targetUrl);
-    final String path = uri != null ? uri.getPath() : null;
-    return uri == null ? null : getFactoryItem(uri, null, path, false).getDefaultRequestConfig();
+    return getDefaultRequestConfig(uri);
   }
 
   @Override
-  public RequestConfig getDefaultRequestConfig(URI targetUrl) {
-    return getFactoryItem(targetUrl, null, targetUrl.getPath(), false).getDefaultRequestConfig();
+  public @NotNull RequestConfig getDefaultRequestConfig(@Nullable URI targetUrl) {
+    String path = targetUrl != null ? targetUrl.getPath() : null;
+    return getFactoryItem(targetUrl, null, path, false).getDefaultRequestConfig();
   }
 
-  private HttpAsyncClientItem getFactoryItem(URI targetUrl, String wsAddressingToUri, String path, boolean isWsCall) {
+  private @NotNull HttpAsyncClientItem getFactoryItem(@Nullable URI targetUrl, @Nullable String wsAddressingToUri, @Nullable String path, boolean isWsCall) {
     for (HttpAsyncClientItem item : factoryItems.values()) {
-      if (item.matches(targetUrl.getHost(), wsAddressingToUri, path, isWsCall)) {
+      String host = targetUrl != null ? targetUrl.getHost() : null;
+      if (item.matches(host, wsAddressingToUri, path, isWsCall)) {
         return item;
       }
     }
     return defaultFactoryItem;
   }
 
-  private URI toUri(String uri) {
+  private @Nullable URI toUri(@Nullable String uri) {
     if (StringUtils.isEmpty(uri)) {
       return null;
     }

--- a/httpasyncclient/src/main/java/io/wcm/caravan/commons/httpasyncclient/impl/HttpAsyncClientItem.java
+++ b/httpasyncclient/src/main/java/io/wcm/caravan/commons/httpasyncclient/impl/HttpAsyncClientItem.java
@@ -44,6 +44,8 @@ import org.apache.http.nio.conn.SchemeIOSessionStrategy;
 import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.http.nio.reactor.ConnectingIOReactor;
 import org.apache.http.nio.reactor.IOReactorException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +66,7 @@ class HttpAsyncClientItem {
   /**
    * @param config Http client configuration
    */
-  HttpAsyncClientItem(HttpClientConfig config) {
+  HttpAsyncClientItem(@NotNull HttpClientConfig config) {
     this.config = config;
 
     // optional SSL client certificate support
@@ -104,7 +106,7 @@ class HttpAsyncClientItem {
     httpAsyncClient.start();
   }
 
-  private static RequestConfig buildDefaultRequestConfig(HttpClientConfig config) {
+  private static @NotNull RequestConfig buildDefaultRequestConfig(@NotNull HttpClientConfig config) {
     return RequestConfig.custom()
             .setConnectionRequestTimeout(config.getConnectionRequestTimeout())
             .setConnectTimeout(config.getConnectTimeout())
@@ -113,8 +115,8 @@ class HttpAsyncClientItem {
             .build();
   }
 
-  private static PoolingNHttpClientConnectionManager buildAsyncConnectionManager(HttpClientConfig config,
-      SSLContext sslContext) {
+  private static @NotNull PoolingNHttpClientConnectionManager buildAsyncConnectionManager(@NotNull HttpClientConfig config,
+      @NotNull SSLContext sslContext) {
     // scheme configuration
     SchemeIOSessionStrategy sslSocketFactory = new SSLIOSessionStrategy(sslContext);
     Registry<SchemeIOSessionStrategy> asyncSchemeRegistry = RegistryBuilder.<SchemeIOSessionStrategy>create()
@@ -136,9 +138,9 @@ class HttpAsyncClientItem {
     return conmgr;
   }
 
-  private static CloseableHttpAsyncClient buildHttpAsyncClient(HttpClientConfig config,
-      PoolingNHttpClientConnectionManager connectionManager, CredentialsProvider credentialsProvider,
-      RequestConfig defaultRequestConfig) {
+  private static @NotNull CloseableHttpAsyncClient buildHttpAsyncClient(@NotNull HttpClientConfig config,
+      @NotNull PoolingNHttpClientConnectionManager connectionManager, @NotNull CredentialsProvider credentialsProvider,
+      @NotNull RequestConfig defaultRequestConfig) {
 
     // prepare HTTPClient builder
     HttpAsyncClientBuilder httpClientAsyncBuilder = HttpAsyncClientBuilder.create()
@@ -165,14 +167,14 @@ class HttpAsyncClientItem {
   /**
    * @return Http client instance (asynchronous)
    */
-  public CloseableHttpAsyncClient getHttpAsyncClient() {
+  public @NotNull CloseableHttpAsyncClient getHttpAsyncClient() {
     return httpAsyncClient;
   }
 
   /**
    * @return Default request config
    */
-  public RequestConfig getDefaultRequestConfig() {
+  public @NotNull RequestConfig getDefaultRequestConfig() {
     return defaultRequestConfig;
   }
 
@@ -183,7 +185,7 @@ class HttpAsyncClientItem {
    * @param isWsCall indicates if the call is a soap webservice call
    * @return true if host name is associated with this http client config
    */
-  public boolean matches(String hostName, String wsAddressingToURI, String path, boolean isWsCall) {
+  public boolean matches(@Nullable String hostName, @Nullable String wsAddressingToURI, @Nullable String path, boolean isWsCall) {
     if (isWsCall) {
       return config.isEnabled()
           && config.matchesHost(hostName)
@@ -210,7 +212,7 @@ class HttpAsyncClientItem {
   }
 
   @Override
-  public String toString() {
+  public @NotNull String toString() {
     return "HttpClientItem[" + config.toString() + "]";
   }
 

--- a/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/HttpClientConfig.java
+++ b/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/HttpClientConfig.java
@@ -20,6 +20,8 @@
 package io.wcm.caravan.commons.httpclient;
 
 import org.apache.http.client.config.CookieSpecs;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ConsumerType;
 
 /**
@@ -100,24 +102,30 @@ public interface HttpClientConfig {
    * Standard cookie specification for HttpClient.
    * @return Cookie spec
    */
-  String getCookieSpec();
+  @NotNull
+  default String getCookieSpec() {
+    return HttpClientConfig.COOKIE_SPEC_DEFAULT;
+  }
 
   /**
    * Http basic authentication user (optional).
    * @return Http user or null.
    */
+  @Nullable
   String getHttpUser();
 
   /**
    * Http basic authentication password (optional).
    * @return Http password or null.
    */
+  @Nullable
   String getHttpPassword();
 
   /**
    * Proxy host (optional).
    * @return Proxy host or null.
    */
+  @Nullable
   String getProxyHost();
 
   /**
@@ -130,12 +138,14 @@ public interface HttpClientConfig {
    * Proxy user (optional).
    * @return Proxy user or null.
    */
+  @Nullable
   String getProxyUser();
 
   /**
    * Proxy password (optional).
    * @return Proxy password or null.
    */
+  @Nullable
   String getProxyPassword();
 
   /**
@@ -143,42 +153,46 @@ public interface HttpClientConfig {
    * @param host Host name
    * @return true if configuration matches.
    */
-  boolean matchesHost(String host);
+  boolean matchesHost(@Nullable String host);
 
   /**
    * Check if this configuration should be applied for a given WS addressing to URI.
    * @param addressingToUri Web service address
    * @return true if configuration matches.
    */
-  boolean matchesWsAddressingToUri(String addressingToUri);
+  boolean matchesWsAddressingToUri(@Nullable String addressingToUri);
 
   /**
    * Check if this configuration should be applied for a given path of the target URL
    * @param path Path part
    * @return true if configuration matches
    */
-  default boolean matchesPath(String path) {
+  default boolean matchesPath(@Nullable String path) {
     return true;
   }
 
   /**
    * @return SSL context type (default: TLS)
    */
+  @NotNull
   String getSslContextType();
 
   /**
    * @return Key manager type (default: SunX509)
    */
+  @NotNull
   String getKeyManagerType();
 
   /**
    * @return Key store type (default: PKCS12)
    */
+  @NotNull
   String getKeyStoreType();
 
   /**
    * @return Key store provider (default: null = use first matching security provider)
    */
+  @Nullable
   default String getKeyStoreProvider() {
     return null;
   }
@@ -186,26 +200,31 @@ public interface HttpClientConfig {
   /**
    * @return Key store file path
    */
+  @Nullable
   String getKeyStorePath();
 
   /**
    * @return Key store password
    */
+  @Nullable
   String getKeyStorePassword();
 
   /**
    * @return Trust manager type (default: SunX509)
    */
+  @NotNull
   String getTrustManagerType();
 
   /**
    * @return Trust store type (default: JKS)
    */
+  @NotNull
   String getTrustStoreType();
 
   /**
    * @return Trust store provider (default: null = use first matching security provider)
    */
+  @Nullable
   default String getTrustStoreProvider() {
     return null;
   }
@@ -213,11 +232,13 @@ public interface HttpClientConfig {
   /**
    * @return Trust store file path
    */
+  @Nullable
   String getTrustStorePath();
 
   /**
    * @return Trust store password
    */
+  @Nullable
   String getTrustStorePassword();
 
 }

--- a/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/HttpClientFactory.java
+++ b/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/HttpClientFactory.java
@@ -24,6 +24,8 @@ import java.net.URI;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -38,7 +40,8 @@ public interface HttpClientFactory {
    * @param targetUrl Target URL to call (this url is not called, but required to check for configuration)
    * @return Http Client
    */
-  HttpClient get(String targetUrl);
+  @NotNull
+  HttpClient get(@Nullable String targetUrl);
 
   /**
    * Returns a configured synchronous Http Client for the given target URL. If a special configuration
@@ -46,7 +49,8 @@ public interface HttpClientFactory {
    * @param targetUrl Target URL to call (this url is not called, but required to check for configuration)
    * @return Http Client
    */
-  CloseableHttpClient getCloseable(String targetUrl);
+  @NotNull
+  CloseableHttpClient getCloseable(@Nullable String targetUrl);
 
   /**
    * Returns a configured synchronous Http Client for the given target URL. If a special configuration
@@ -54,7 +58,8 @@ public interface HttpClientFactory {
    * @param targetUrl Target URL to call (this url is not called, but required to check for configuration)
    * @return Http Client
    */
-  HttpClient get(URI targetUrl);
+  @NotNull
+  HttpClient get(@Nullable URI targetUrl);
 
   /**
    * Returns a configured synchronous Http Client for the given target URL. If a special configuration
@@ -62,7 +67,8 @@ public interface HttpClientFactory {
    * @param targetUrl Target URL to call (this url is not called, but required to check for configuration)
    * @return Http Client
    */
-  CloseableHttpClient getCloseable(URI targetUrl);
+  @NotNull
+  CloseableHttpClient getCloseable(@Nullable URI targetUrl);
 
   /**
    * Returns a configured synchronous Http Client for the given target URL. The Http Client is dedicated
@@ -73,7 +79,8 @@ public interface HttpClientFactory {
    * @param wsAddressingToUri WS Addressing "To" header
    * @return Http Client
    */
-  HttpClient getWs(String targetUrl, String wsAddressingToUri);
+  @NotNull
+  HttpClient getWs(@Nullable String targetUrl, @Nullable String wsAddressingToUri);
 
   /**
    * Returns a configured synchronous Http Client for the given target URL. The Http Client is dedicated
@@ -84,7 +91,8 @@ public interface HttpClientFactory {
    * @param wsAddressingToUri WS Addressing "To" header
    * @return Http Client
    */
-  CloseableHttpClient getCloseableWs(String targetUrl, String wsAddressingToUri);
+  @NotNull
+  CloseableHttpClient getCloseableWs(@Nullable String targetUrl, @Nullable String wsAddressingToUri);
 
   /**
    * Returns a configured synchronous Http Client for the given target URL. The Http Client is dedicated
@@ -95,7 +103,8 @@ public interface HttpClientFactory {
    * @param wsAddressingToUri WS Addressing "To" header
    * @return Http Client
    */
-  HttpClient getWs(URI targetUrl, URI wsAddressingToUri);
+  @NotNull
+  HttpClient getWs(@Nullable URI targetUrl, @Nullable URI wsAddressingToUri);
 
   /**
    * Returns a configured synchronous Http Client for the given target URL. The Http Client is dedicated
@@ -106,7 +115,8 @@ public interface HttpClientFactory {
    * @param wsAddressingToUri WS Addressing "To" header
    * @return Http Client
    */
-  CloseableHttpClient getCloseableWs(URI targetUrl, URI wsAddressingToUri);
+  @NotNull
+  CloseableHttpClient getCloseableWs(@Nullable URI targetUrl, @Nullable URI wsAddressingToUri);
 
   /**
    * Returns the default Request Configuration for the given target URL. If a special configuration
@@ -114,7 +124,8 @@ public interface HttpClientFactory {
    * @param targetUrl Target URL to call (this url is not called, but required to check for configuration)
    * @return Default Request Config
    */
-  RequestConfig getDefaultRequestConfig(String targetUrl);
+  @NotNull
+  RequestConfig getDefaultRequestConfig(@Nullable String targetUrl);
 
   /**
    * Returns the default Request Configuration for the given target URL. If a special configuration
@@ -122,6 +133,7 @@ public interface HttpClientFactory {
    * @param targetUrl Target URL to call (this url is not called, but required to check for configuration)
    * @return Default Request Config
    */
-  RequestConfig getDefaultRequestConfig(URI targetUrl);
+  @NotNull
+  RequestConfig getDefaultRequestConfig(@Nullable URI targetUrl);
 
 }

--- a/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/HttpClientConfigImpl.java
+++ b/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/HttpClientConfigImpl.java
@@ -26,6 +26,8 @@ import java.util.regex.PatternSyntaxException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.config.CookieSpecs;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -362,22 +364,22 @@ public class HttpClientConfigImpl extends AbstractHttpClientConfig {
   }
 
   @Override
-  public String getCookieSpec() {
+  public @NotNull String getCookieSpec() {
     return cookieSpec;
   }
 
   @Override
-  public String getHttpUser() {
+  public @Nullable String getHttpUser() {
     return httpUser;
   }
 
   @Override
-  public String getHttpPassword() {
+  public @Nullable String getHttpPassword() {
     return httpPassword;
   }
 
   @Override
-  public String getProxyHost() {
+  public @Nullable String getProxyHost() {
     return proxyHost;
   }
 
@@ -387,17 +389,17 @@ public class HttpClientConfigImpl extends AbstractHttpClientConfig {
   }
 
   @Override
-  public String getProxyUser() {
+  public @Nullable String getProxyUser() {
     return proxyUser;
   }
 
   @Override
-  public String getProxyPassword() {
+  public @Nullable String getProxyPassword() {
     return proxyPassword;
   }
 
   @Override
-  public boolean matchesHost(String host) {
+  public boolean matchesHost(@Nullable String host) {
     if (hostPatterns.isEmpty()) {
       return true;
     }
@@ -413,7 +415,7 @@ public class HttpClientConfigImpl extends AbstractHttpClientConfig {
   }
 
   @Override
-  public boolean matchesWsAddressingToUri(String addressingToUri) {
+  public boolean matchesWsAddressingToUri(@Nullable String addressingToUri) {
     if (wsAddressingToUris.isEmpty()) {
       return true;
     }
@@ -424,7 +426,7 @@ public class HttpClientConfigImpl extends AbstractHttpClientConfig {
   }
 
   @Override
-  public boolean matchesPath(final String path) {
+  public boolean matchesPath(@Nullable String path) {
     if (pathPatterns.isEmpty()) {
       return true;
     }
@@ -440,57 +442,57 @@ public class HttpClientConfigImpl extends AbstractHttpClientConfig {
   }
 
   @Override
-  public String getSslContextType() {
+  public @NotNull String getSslContextType() {
     return sslContextType;
   }
 
   @Override
-  public String getKeyManagerType() {
+  public @NotNull String getKeyManagerType() {
     return keyManagerType;
   }
 
   @Override
-  public String getKeyStoreType() {
+  public @NotNull String getKeyStoreType() {
     return keyStoreType;
   }
 
   @Override
-  public String getKeyStoreProvider() {
+  public @Nullable String getKeyStoreProvider() {
     return keyStoreProvider;
   }
 
   @Override
-  public String getKeyStorePath() {
+  public @Nullable String getKeyStorePath() {
     return keyStorePath;
   }
 
   @Override
-  public String getKeyStorePassword() {
+  public @Nullable String getKeyStorePassword() {
     return keyStorePassword;
   }
 
   @Override
-  public String getTrustManagerType() {
+  public @NotNull String getTrustManagerType() {
     return trustManagerType;
   }
 
   @Override
-  public String getTrustStoreType() {
+  public @NotNull String getTrustStoreType() {
     return trustStoreType;
   }
 
   @Override
-  public String getTrustStoreProvider() {
+  public @Nullable String getTrustStoreProvider() {
     return trustStoreProvider;
   }
 
   @Override
-  public String getTrustStorePath() {
+  public @Nullable String getTrustStorePath() {
     return trustStorePath;
   }
 
   @Override
-  public String getTrustStorePassword() {
+  public @Nullable String getTrustStorePassword() {
     return trustStorePassword;
   }
 

--- a/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/HttpClientFactoryImpl.java
+++ b/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/HttpClientFactoryImpl.java
@@ -31,6 +31,8 @@ import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.sling.commons.osgi.Order;
 import org.apache.sling.commons.osgi.ServiceUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -84,71 +86,75 @@ public class HttpClientFactoryImpl implements HttpClientFactory {
   }
 
   @Override
-  public CloseableHttpClient get(String targetUrl) {
+  public @NotNull CloseableHttpClient get(@Nullable String targetUrl) {
     return getCloseable(targetUrl);
   }
 
   @Override
-  public CloseableHttpClient getCloseable(String targetUrl) {
+  public @NotNull CloseableHttpClient getCloseable(@Nullable String targetUrl) {
     final URI uri = toUri(targetUrl);
     final String path = uri != null ? uri.getPath() : null;
     return getFactoryItem(uri, null, path, false).getHttpClient();
   }
 
   @Override
-  public HttpClient get(URI targetUrl) {
+  public @NotNull HttpClient get(@Nullable URI targetUrl) {
     return getCloseable(targetUrl);
   }
 
   @Override
-  public CloseableHttpClient getCloseable(URI targetUrl) {
-    return getFactoryItem(targetUrl, null, targetUrl.getPath(), false).getHttpClient();
+  public @NotNull CloseableHttpClient getCloseable(@Nullable URI targetUrl) {
+    String path = targetUrl != null ? targetUrl.getPath() : null;
+    return getFactoryItem(targetUrl, null, path, false).getHttpClient();
   }
 
   @Override
-  public HttpClient getWs(String targetUrl, String wsAddressingToUri) {
+  public @NotNull HttpClient getWs(@Nullable String targetUrl, @Nullable String wsAddressingToUri) {
     return getCloseableWs(targetUrl, wsAddressingToUri);
   }
 
   @Override
-  public CloseableHttpClient getCloseableWs(String targetUrl, String wsAddressingToUri) {
+  public @NotNull CloseableHttpClient getCloseableWs(@Nullable String targetUrl, @Nullable String wsAddressingToUri) {
     final URI uri = toUri(targetUrl);
     final String path = uri != null ? uri.getPath() : null;
     return getFactoryItem(uri, wsAddressingToUri, path, true).getHttpClient();
   }
 
   @Override
-  public HttpClient getWs(URI targetUrl, URI wsAddressingToUri) {
+  public @NotNull HttpClient getWs(@Nullable URI targetUrl, @Nullable URI wsAddressingToUri) {
     return getCloseableWs(targetUrl, wsAddressingToUri);
   }
 
   @Override
-  public CloseableHttpClient getCloseableWs(URI targetUrl, URI wsAddressingToUri) {
-    return getFactoryItem(targetUrl, wsAddressingToUri.toString(), targetUrl.getPath(), true).getHttpClient();
+  public @NotNull CloseableHttpClient getCloseableWs(@Nullable URI targetUrl, @Nullable URI wsAddressingToUri) {
+    String wsAddressingToUriString = wsAddressingToUri != null ? wsAddressingToUri.toString() : null;
+    String path = targetUrl != null ? targetUrl.getPath() : null;
+    return getFactoryItem(targetUrl, wsAddressingToUriString, path, true).getHttpClient();
   }
 
   @Override
-  public RequestConfig getDefaultRequestConfig(String targetUrl) {
+  public @NotNull RequestConfig getDefaultRequestConfig(@Nullable String targetUrl) {
     final URI uri = toUri(targetUrl);
-    final String path = uri != null ? uri.getPath() : null;
-    return uri == null ? null : getFactoryItem(uri, null, path, false).getDefaultRequestConfig();
+    return getDefaultRequestConfig(uri);
   }
 
   @Override
-  public RequestConfig getDefaultRequestConfig(URI targetUrl) {
-    return getFactoryItem(targetUrl, null, targetUrl.getPath(), false).getDefaultRequestConfig();
+  public @NotNull RequestConfig getDefaultRequestConfig(@Nullable URI targetUrl) {
+    String path = targetUrl != null ? targetUrl.getPath() : null;
+    return getFactoryItem(targetUrl, null, path, false).getDefaultRequestConfig();
   }
 
-  private HttpClientItem getFactoryItem(URI targetUrl, String wsAddressingToUri, String path, boolean isWsCall) {
+  private @NotNull HttpClientItem getFactoryItem(@Nullable URI targetUrl, @Nullable String wsAddressingToUri, @Nullable String path, boolean isWsCall) {
     for (HttpClientItem item : factoryItems.values()) {
-      if (item.matches(targetUrl.getHost(), wsAddressingToUri, path, isWsCall)) {
+      String host = targetUrl != null ? targetUrl.getHost() : null;
+      if (item.matches(host, wsAddressingToUri, path, isWsCall)) {
         return item;
       }
     }
     return defaultFactoryItem;
   }
 
-  private URI toUri(String uri) {
+  private @Nullable URI toUri(@Nullable String uri) {
     if (StringUtils.isEmpty(uri)) {
       return null;
     }

--- a/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/HttpClientItem.java
+++ b/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/HttpClientItem.java
@@ -40,6 +40,8 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.ProxyAuthenticationStrategy;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +62,7 @@ class HttpClientItem {
   /**
    * @param config Http client configuration
    */
-  HttpClientItem(HttpClientConfig config) {
+  HttpClientItem(@NotNull HttpClientConfig config) {
     this.config = config;
 
     // optional SSL client certificate support
@@ -97,7 +99,7 @@ class HttpClientItem {
     httpClient = buildHttpClient(config, connectionManager, credentialsProvider, defaultRequestConfig);
   }
 
-  private static RequestConfig buildDefaultRequestConfig(HttpClientConfig config) {
+  private static @NotNull RequestConfig buildDefaultRequestConfig(@NotNull HttpClientConfig config) {
     return RequestConfig.custom()
         // timeout settings
         .setConnectionRequestTimeout(config.getConnectionRequestTimeout())
@@ -107,8 +109,8 @@ class HttpClientItem {
         .build();
   }
 
-  private static PoolingHttpClientConnectionManager buildConnectionManager(HttpClientConfig config,
-      SSLContext sslContext) {
+  private static @NotNull PoolingHttpClientConnectionManager buildConnectionManager(@NotNull HttpClientConfig config,
+      @NotNull SSLContext sslContext) {
     // scheme configuration
     ConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext);
     Registry<ConnectionSocketFactory> schemeRegistry = RegistryBuilder.<ConnectionSocketFactory>create()
@@ -123,9 +125,9 @@ class HttpClientItem {
     return conmgr;
   }
 
-  private static CloseableHttpClient buildHttpClient(HttpClientConfig config,
-      PoolingHttpClientConnectionManager connectionManager, CredentialsProvider credentialsProvider,
-      RequestConfig defaultRequestConfig) {
+  private static @NotNull CloseableHttpClient buildHttpClient(@NotNull HttpClientConfig config,
+      @NotNull PoolingHttpClientConnectionManager connectionManager, @NotNull CredentialsProvider credentialsProvider,
+      @NotNull RequestConfig defaultRequestConfig) {
 
     // prepare HTTPClient builder
     HttpClientBuilder httpClientBuilder = HttpClientBuilder.create()
@@ -151,14 +153,14 @@ class HttpClientItem {
   /**
    * @return Http client instance (synchronous)
    */
-  public CloseableHttpClient getHttpClient() {
+  public @NotNull CloseableHttpClient getHttpClient() {
     return httpClient;
   }
 
   /**
    * @return Default request config
    */
-  public RequestConfig getDefaultRequestConfig() {
+  public @NotNull RequestConfig getDefaultRequestConfig() {
     return defaultRequestConfig;
   }
 
@@ -169,7 +171,7 @@ class HttpClientItem {
    * @param isWsCall indicates if the call is a soap webservice call
    * @return true if host name is associated with this http client config
    */
-  public boolean matches(String hostName, String wsAddressingToURI, String path, boolean isWsCall) {
+  public boolean matches(@Nullable String hostName, @Nullable String wsAddressingToURI, @Nullable String path, boolean isWsCall) {
     if (isWsCall) {
       return config.isEnabled()
           && config.matchesHost(hostName)
@@ -196,7 +198,8 @@ class HttpClientItem {
   }
 
   @Override
-  public String toString() {
+  public @NotNull String toString() {
     return "HttpClientItem[" + config.toString() + "]";
   }
+
 }

--- a/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/helpers/AbstractHttpClientConfig.java
+++ b/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/helpers/AbstractHttpClientConfig.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.jetbrains.annotations.NotNull;
 
 import io.wcm.caravan.commons.httpclient.HttpClientConfig;
 
@@ -42,7 +43,7 @@ public abstract class AbstractHttpClientConfig implements HttpClientConfig {
   };
 
   @Override
-  public String toString() {
+  public @NotNull String toString() {
     ToStringBuilder builder = new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE);
     Map<String, Object> properties = BeanUtil.getMaskedBeanProperties(this, SENSITIVE_PROPERTY_NAMES);
     for (Map.Entry<String, Object> entry : properties.entrySet()) {

--- a/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/helpers/BeanUtil.java
+++ b/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/helpers/BeanUtil.java
@@ -24,6 +24,8 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.apache.commons.beanutils.BeanUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Helper methods for managing java beans.
@@ -42,7 +44,7 @@ final class BeanUtil {
    * @param maskProperties List of property names
    * @return Map with masked key/value pairs
    */
-  public static SortedMap<String, Object> getMaskedBeanProperties(Object beanObject, String[] maskProperties) {
+  public static @NotNull SortedMap<String, Object> getMaskedBeanProperties(@NotNull Object beanObject, @NotNull String @Nullable [] maskProperties) {
     try {
       SortedMap<String, Object> configProperties = new TreeMap<>(BeanUtils.describe(beanObject));
 

--- a/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/helpers/CertificateLoader.java
+++ b/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/helpers/CertificateLoader.java
@@ -35,7 +35,10 @@ import javax.net.ssl.TrustManagerFactory;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.conn.ssl.SSLInitializationException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.wcm.caravan.commons.httpclient.HttpClientConfig;
 
 /**
@@ -80,7 +83,9 @@ public final class CertificateLoader {
    * @throws IOException I/O exception
    * @throws GeneralSecurityException General security exception
    */
-  public static SSLContext buildSSLContext(HttpClientConfig config) throws IOException, GeneralSecurityException {
+  @SuppressWarnings("null")
+  @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE") // null checks happen in separate methods
+  public static @NotNull SSLContext buildSSLContext(@NotNull HttpClientConfig config) throws IOException, GeneralSecurityException {
 
     KeyManagerFactory kmf = null;
     if (isSslKeyManagerEnabled(config)) {
@@ -110,7 +115,7 @@ public final class CertificateLoader {
    * @throws IOException I/O exception
    * @throws GeneralSecurityException General security exception
    */
-  public static KeyManagerFactory getKeyManagerFactory(String keyStoreFilename, StoreProperties storeProperties)
+  public static @NotNull KeyManagerFactory getKeyManagerFactory(@NotNull String keyStoreFilename, @NotNull StoreProperties storeProperties)
       throws IOException, GeneralSecurityException {
     InputStream is = getResourceAsStream(keyStoreFilename);
     if (is == null) {
@@ -137,7 +142,7 @@ public final class CertificateLoader {
    * @throws IOException I/O exception
    * @throws GeneralSecurityException General security exception
    */
-  private static KeyManagerFactory getKeyManagerFactory(InputStream keyStoreStream, StoreProperties storeProperties)
+  private static @NotNull KeyManagerFactory getKeyManagerFactory(@NotNull InputStream keyStoreStream, @NotNull StoreProperties storeProperties)
       throws IOException, GeneralSecurityException {
     // use provider if given, otherwise use the first matching security provider
     final KeyStore ks;
@@ -161,7 +166,7 @@ public final class CertificateLoader {
    * @throws IOException I/O exception
    * @throws GeneralSecurityException General security exception
    */
-  public static TrustManagerFactory getTrustManagerFactory(String trustStoreFilename, StoreProperties storeProperties)
+  public static @NotNull TrustManagerFactory getTrustManagerFactory(@NotNull String trustStoreFilename, @NotNull StoreProperties storeProperties)
       throws IOException, GeneralSecurityException {
     InputStream is = getResourceAsStream(trustStoreFilename);
     if (is == null) {
@@ -188,7 +193,7 @@ public final class CertificateLoader {
    * @throws IOException I/O exception
    * @throws GeneralSecurityException General security exception
    */
-  private static TrustManagerFactory getTrustManagerFactory(InputStream trustStoreStream, StoreProperties storeProperties)
+  private static @NotNull TrustManagerFactory getTrustManagerFactory(@NotNull InputStream trustStoreStream, @NotNull StoreProperties storeProperties)
       throws IOException, GeneralSecurityException {
 
     // use provider if given, otherwise use the first matching security provider
@@ -212,7 +217,7 @@ public final class CertificateLoader {
    * @return InputStream or null if neither file nor classpath resource is found
    * @throws IOException I/O exception
    */
-  private static InputStream getResourceAsStream(String path) throws IOException {
+  private static @Nullable InputStream getResourceAsStream(@NotNull String path) throws IOException {
     if (StringUtils.isEmpty(path)) {
       return null;
     }
@@ -232,7 +237,7 @@ public final class CertificateLoader {
    * @param path Path
    * @return Absolute path
    */
-  private static String getFilenameInfo(String path) {
+  private static @Nullable String getFilenameInfo(@Nullable String path) {
     if (StringUtils.isEmpty(path)) {
       return null;
     }
@@ -249,7 +254,7 @@ public final class CertificateLoader {
    * @param config Http client configuration
    * @return true if client certificates are enabled
    */
-  public static boolean isSslKeyManagerEnabled(HttpClientConfig config) {
+  public static boolean isSslKeyManagerEnabled(@NotNull HttpClientConfig config) {
     return StringUtils.isNotEmpty(config.getSslContextType())
         && StringUtils.isNotEmpty(config.getKeyManagerType())
         && StringUtils.isNotEmpty(config.getKeyStoreType())
@@ -261,7 +266,7 @@ public final class CertificateLoader {
    * @param config Http client configuration
    * @return true if client certificates are enabled
    */
-  public static boolean isSslTrustStoreEnbaled(HttpClientConfig config) {
+  public static boolean isSslTrustStoreEnbaled(@NotNull HttpClientConfig config) {
     return StringUtils.isNotEmpty(config.getSslContextType())
         && StringUtils.isNotEmpty(config.getTrustManagerType())
         && StringUtils.isNotEmpty(config.getTrustStoreType())
@@ -272,16 +277,13 @@ public final class CertificateLoader {
    * Creates default SSL context.
    * @return SSL context
    */
-  public static SSLContext createDefaultSSlContext() throws SSLInitializationException {
+  public static @NotNull SSLContext createDefaultSSlContext() throws SSLInitializationException {
     try {
       final SSLContext sslcontext = SSLContext.getInstance(SSL_CONTEXT_TYPE_DEFAULT);
       sslcontext.init(null, null, null);
       return sslcontext;
     }
-    catch (NoSuchAlgorithmException ex) {
-      throw new SSLInitializationException(ex.getMessage(), ex);
-    }
-    catch (KeyManagementException ex) {
+    catch (NoSuchAlgorithmException | KeyManagementException ex) {
       throw new SSLInitializationException(ex.getMessage(), ex);
     }
   }

--- a/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/helpers/DefaultHttpClientConfig.java
+++ b/httpclient/src/main/java/io/wcm/caravan/commons/httpclient/impl/helpers/DefaultHttpClientConfig.java
@@ -19,6 +19,9 @@
  */
 package io.wcm.caravan.commons.httpclient.impl.helpers;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import io.wcm.caravan.commons.httpclient.HttpClientConfig;
 
 /**
@@ -66,22 +69,22 @@ public final class DefaultHttpClientConfig extends AbstractHttpClientConfig {
   }
 
   @Override
-  public String getCookieSpec() {
+  public @NotNull String getCookieSpec() {
     return HttpClientConfig.COOKIE_SPEC_DEFAULT;
   }
 
   @Override
-  public String getHttpUser() {
+  public @Nullable String getHttpUser() {
     return null;
   }
 
   @Override
-  public String getHttpPassword() {
+  public @Nullable String getHttpPassword() {
     return null;
   }
 
   @Override
-  public String getProxyHost() {
+  public @Nullable String getProxyHost() {
     return null;
   }
 
@@ -91,82 +94,82 @@ public final class DefaultHttpClientConfig extends AbstractHttpClientConfig {
   }
 
   @Override
-  public String getProxyUser() {
+  public @Nullable String getProxyUser() {
     return null;
   }
 
   @Override
-  public String getProxyPassword() {
+  public @Nullable String getProxyPassword() {
     return null;
   }
 
   @Override
-  public boolean matchesHost(String host) {
+  public boolean matchesHost(@Nullable String host) {
     return true;
   }
 
   @Override
-  public boolean matchesWsAddressingToUri(String addressingToUri) {
+  public boolean matchesWsAddressingToUri(@Nullable String addressingToUri) {
     return true;
   }
 
   @Override
-  public boolean matchesPath(final String path) {
+  public boolean matchesPath(@Nullable String path) {
     return true;
   }
 
   @Override
-  public String getSslContextType() {
+  public @NotNull String getSslContextType() {
     return CertificateLoader.SSL_CONTEXT_TYPE_DEFAULT;
   }
 
   @Override
-  public String getKeyManagerType() {
+  public @NotNull String getKeyManagerType() {
     return CertificateLoader.KEY_MANAGER_TYPE_DEFAULT;
   }
 
   @Override
-  public String getKeyStoreType() {
+  public @NotNull String getKeyStoreType() {
     return CertificateLoader.KEY_STORE_TYPE_DEFAULT;
   }
 
   @Override
-  public String getKeyStoreProvider() {
+  public @Nullable String getKeyStoreProvider() {
     return null;
   }
 
   @Override
-  public String getKeyStorePath() {
+  public @Nullable String getKeyStorePath() {
     return null;
   }
 
   @Override
-  public String getKeyStorePassword() {
+  public @Nullable String getKeyStorePassword() {
     return null;
   }
 
   @Override
-  public String getTrustManagerType() {
+  public @NotNull String getTrustManagerType() {
     return CertificateLoader.TRUST_MANAGER_TYPE_DEFAULT;
   }
 
   @Override
-  public String getTrustStoreType() {
+  public @NotNull String getTrustStoreType() {
     return CertificateLoader.TRUST_STORE_TYPE_DEFAULT;
   }
 
   @Override
-  public String getTrustStoreProvider() {
+  public @Nullable String getTrustStoreProvider() {
     return null;
   }
 
   @Override
-  public String getTrustStorePath() {
+  public @Nullable String getTrustStorePath() {
     return null;
   }
 
   @Override
-  public String getTrustStorePassword() {
+  public @Nullable String getTrustStorePassword() {
     return null;
   }
 

--- a/httpclient/src/test/java/io/wcm/caravan/commons/httpclient/impl/helpers/CertificateLoaderTest.java
+++ b/httpclient/src/test/java/io/wcm/caravan/commons/httpclient/impl/helpers/CertificateLoaderTest.java
@@ -69,6 +69,7 @@ public class CertificateLoaderTest {
   }
 
   @Test(expected = FileNotFoundException.class)
+  @SuppressWarnings("null")
   public void testGetKeyManagerFactoryNullPath() throws IOException, GeneralSecurityException {
     CertificateLoader.getKeyManagerFactory(null, new StoreProperties(KEYSTORE_PASSWORD, CertificateLoader.KEY_MANAGER_TYPE_DEFAULT,
         CertificateLoader.KEY_STORE_TYPE_DEFAULT, null));
@@ -86,6 +87,7 @@ public class CertificateLoaderTest {
   }
 
   @Test(expected = FileNotFoundException.class)
+  @SuppressWarnings("null")
   public void testGetTrustManagerFactoryNullPath() throws IOException, GeneralSecurityException {
     CertificateLoader.getTrustManagerFactory(null, STORE_PROPERTIES);
   }


### PR DESCRIPTION
apply null-annotations to all interface to document the contract of expected null/non-null values

getDefaultRequestConfig methods must never return null